### PR TITLE
Minor docs improvements

### DIFF
--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -154,7 +154,7 @@ to run `kea-typegen watch` together with webpack while developing and
 // package.json
 {
     "scripts": { 
-        "start": "concurrently start:webpack start:typegen -n WEBPACK,TYPEGEN -c blue,green",
+        "start": "concurrently \"yarn run start:webpack\" \"yarn run start:typegen\" -n WEBPACK,TYPEGEN -c blue,green",
         "start:typegen": "kea-typegen watch",
         "start:webpack": "webpack-dev-server",
         "build": "yarn run build:typegen && yarn run build:webpack",

--- a/docs/plugins/localstorage.md
+++ b/docs/plugins/localstorage.md
@@ -86,3 +86,7 @@ const logic = kea({
     },
 })
 ```
+
+:::note
+Please be aware that under the hood `kea-localstorage` overrides the default value for the reducer with whatever was stored in `localStorage`. This means that **any listeners** hooked to any actions related to the reducer will **not be triggered** (this is also due to the fact that a reducer may have multiple actions, and there's no way of knowing which one to trigger).
+:::


### PR DESCRIPTION
- Fixes a small issue with a sample `concurrently` command.
- Clarify listener triggers on `kea-localstorage` (more context on https://github.com/keajs/kea-localstorage/issues/20)
