### PR TITLE
Fix selectors example typo

### DIFF
--- a/docs/core/selectors.md
+++ b/docs/core/selectors.md
@@ -144,7 +144,7 @@ const usersLogic = kea([
   loaders({ users: { loadUsers: api.loadUsers } }),
   selectors({
     findById: [
-      (selectors) => [selectors.uesrs],
+      (selectors) => [selectors.users],
       (users) => (id: number) => users.find((user) => user.id === id),
     ],
   }),


### PR DESCRIPTION
Fixes a typo in _[Selectors](https://keajs.org/docs/core/selectors) > [Selectors that return a function](https://keajs.org/docs/core/selectors/#selectors-that-return-functions)_.